### PR TITLE
Don't publish .babelrc file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 src/
 docs/
 demo-src/
+.babelrc


### PR DESCRIPTION
More and more npm packages contain ES2015+ code.
As discussed in [this AMA](https://github.com/sindresorhus/ama/issues/446), this causes a lot of troubles (Uglify and old browsers) for people.

One possible solution is to transpile external dependencies, as discussed in [this issue on create-react-app](https://github.com/facebookincubator/create-react-app/issues/1125) and implemented in [this pull request](https://github.com/facebookincubator/create-react-app/pull/3776).

This doesn't currently work with v-tooltip as the .babelrc file is published on npm.
Here is a [small repo demonstrating the bug](https://github.com/oligot/v-tooltip-babelrc).
Running `npm run build` results in this error

```
ERROR in ./node_modules/v-tooltip/dist/v-tooltip.esm.js
Module build failed: Error: Couldn't find preset "stage-0" relative to directory ".../v-tooltip-babelrc/node_modules/v-tooltip"
```

By adding the .babelrc file to .npmignore, the bug would go away once a new version of v-tooltip is published.