### PR TITLE
Arrow z-index

### DIFF
--- a/demo-src/src/App.vue
+++ b/demo-src/src/App.vue
@@ -194,7 +194,6 @@ label input {
     position: absolute;
     margin: 5px;
     border-color: black;
-    z-index: 1;
   }
 
   &[x-placement^="top"] {

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -19,7 +19,6 @@
 			:aria-hidden="isOpen ? 'false' : 'true'"
 		>
 			<div :class="popoverWrapperClass">
-				<div ref="arrow" :class="popoverArrowClass"></div>
 				<div
 					ref="inner"
 					:class="popoverInnerClass"
@@ -31,6 +30,7 @@
 
 					<ResizeObserver v-if="handleResize" @notify="$_handleResize" />
 				</div>
+				<div ref="arrow" :class="popoverArrowClass"></div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Fix z-index of popover arrow.

Reproduce problem:
Add box-shadow to popover inner and arrow goes under shadow if you don't add z-index for it.

Fix:
Place arrow after inner block -> you dont need use z-index.