### PR TITLE
Fix getting related reference/target on mouseleave

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -528,10 +528,10 @@ export default {
 			const reference = this.$refs.trigger
 			const popoverNode = this.$refs.popover
 
-			const relatedreference = event.relatedreference || event.toElement
+			const relatedreference = event.relatedreference || event.toElement || event.relatedTarget
 
 			const callback = event2 => {
-				const relatedreference2 = event2.relatedreference || event2.toElement
+				const relatedreference2 = event2.relatedreference || event2.toElement || event.relatedTarget
 
 				// Remove event listener after call
 				popoverNode.removeEventListener(event.type, callback)

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -531,7 +531,7 @@ export default {
 			const relatedreference = event.relatedreference || event.toElement || event.relatedTarget
 
 			const callback = event2 => {
-				const relatedreference2 = event2.relatedreference || event2.toElement || event.relatedTarget
+				const relatedreference2 = event2.relatedreference || event2.toElement || event2.relatedTarget
 
 				// Remove event listener after call
 				popoverNode.removeEventListener(event.type, callback)

--- a/src/lib/tooltip.js
+++ b/src/lib/tooltip.js
@@ -566,10 +566,10 @@ export default class Tooltip {
 	}
 
 		_setTooltipNodeEvent = (evt, reference, delay, options) => {
-			const relatedreference = evt.relatedreference || evt.toElement
+			const relatedreference = evt.relatedreference || evt.toElement || evt.relatedTarget
 
 			const callback = evt2 => {
-				const relatedreference2 = evt2.relatedreference || evt2.toElement
+				const relatedreference2 = evt2.relatedreference || evt2.toElement || evt2.relatedTarget
 
 				// Remove event listener after call
 				this._tooltipNode.removeEventListener(evt.type, callback)


### PR DESCRIPTION
Getting the target for mouseleave in popovers and tooltips was only working on Chrome. It looks like it was a bug in tooltip.js that was eventually fixed. Pretty small change.

Relevant MDN: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/relatedTarget
Relevant line in tooltip.js: https://github.com/FezVrasta/popper.js/blob/master/packages/tooltip/src/index.js#L404