### PR TITLE
Add `String` to `boundariesElement` prop allowed types

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -100,7 +100,7 @@ export default {
 			default: () => getDefault('defaultContainer'),
 		},
 		boundariesElement: {
-			type: Element,
+			type: [String, Element],
 			default: () => getDefault('defaultBoundariesElement'),
 		},
 		popperOptions: {


### PR DESCRIPTION
Hi there! This is just a simple fix for #79. Popper.js allows either a string or an element for this. Please let me know if this PR needs anything else.