### PR TITLE
Transform arrow functions into class methods

### DIFF
--- a/src/lib/tooltip.js
+++ b/src/lib/tooltip.js
@@ -78,7 +78,7 @@ export default class Tooltip {
 	 * @method Tooltip#show
 	 * @memberof Tooltip
 	 */
-	show = () => {
+	show () {
 		this._show(this.reference, this.options)
 	}
 
@@ -87,7 +87,7 @@ export default class Tooltip {
 	 * @method Tooltip#hide
 	 * @memberof Tooltip
 	 */
-	hide = () => {
+	hide () {
 		this._hide()
 	}
 
@@ -96,7 +96,7 @@ export default class Tooltip {
 	 * @method Tooltip#dispose
 	 * @memberof Tooltip
 	 */
-	dispose = () => {
+	dispose () {
 		this._dispose()
 	}
 
@@ -105,7 +105,7 @@ export default class Tooltip {
 	 * @method Tooltip#toggle
 	 * @memberof Tooltip
 	 */
-	toggle = () => {
+	toggle () {
 		if (this._isOpen) {
 			return this.hide()
 		} else {


### PR DESCRIPTION
The objective is consistency with the rest of the code.

I stumbled into this problem when wanting to use the unbundled library, in order to avoid duplicating shared dependencies (poppers.js), by directly importing `v-tooltip/src/index.js`. The bundler of the module I wanted to fix stumbles upon the arrow functions as class properties.
