### PR TITLE
Update Popover.vue - fix auto close

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -634,20 +634,18 @@ function handleGlobalTouchend (event) {
 }
 
 function handleGlobalClose(event) {
-  var touch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-  var _contains = popover.$refs.popover.contains(event.target);
-  
-  // Delay so that close directive has time to set values
-  requestAnimationFrame((function (contains) {
+    var touch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
     var popover = void 0;
     for (var i = 0; i < openPopovers.length; i++) {
       popover = openPopovers[i];
       if (popover.$refs.popover) {
+        var contains = popover.$refs.popover.contains(event.target);
         if (event.closeAllPopover || event.closePopover && contains || popover.autoHide && !contains) {
-          popover.$_handleGlobalClose(event, touch);
+          // Delay so that close directive has time to set values
+          requestAnimationFrame(popover.$_handleGlobalClose.bind(this, event, touch));
         }
       }
     }
-  }).bind(_contains));
-}
+  }
 </script>

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -633,19 +633,21 @@ function handleGlobalTouchend (event) {
 	handleGlobalClose(event, true)
 }
 
-function handleGlobalClose (event, touch = false) {
-	// Delay so that close directive has time to set values
-	requestAnimationFrame(() => {
-		let popover
-		for (let i = 0; i < openPopovers.length; i++) {
-			popover = openPopovers[i]
-			if (popover.$refs.popover) {
-				const contains = popover.$refs.popover.contains(event.target)
-				if (event.closeAllPopover || (event.closePopover && contains) || (popover.autoHide && !contains)) {
-					popover.$_handleGlobalClose(event, touch)
-				}
-			}
-		}
-	})
+function handleGlobalClose(event) {
+  var touch = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+  var _contains = popover.$refs.popover.contains(event.target);
+  
+  // Delay so that close directive has time to set values
+  requestAnimationFrame((function (contains) {
+    var popover = void 0;
+    for (var i = 0; i < openPopovers.length; i++) {
+      popover = openPopovers[i];
+      if (popover.$refs.popover) {
+        if (event.closeAllPopover || event.closePopover && contains || popover.autoHide && !contains) {
+          popover.$_handleGlobalClose(event, touch);
+        }
+      }
+    }
+  }).bind(_contains));
 }
 </script>


### PR DESCRIPTION
Thank you for your wonderful component v-tooltip.

There is a bug in it:
It listens on window click event, and if the element clicked is outside the popover - the popover is closed.
BUT. the check if the element is inside the container, happens with a delay, therefore, if the element WAS inside, but on click is removed - then the popover won't know it was there.
