### PR TITLE
Updated defaultHtml to false and noted in readme to reduce risk of XSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,8 @@ The default global options are:
 	// Default CSS classes applied to the target element of the tooltip
 	defaultTargetClass: 'has-tooltip',
 	// Is the content HTML by default?
-	defaultHtml: true,
+	// Disabled by default to reduce the risk of Cross-Site Scripting
+	defaultHtml: false,
 	// Default HTML template of the tooltip element
 	// It must include `tooltip-arrow` & `tooltip-inner` CSS classes (can be configured, see below)
 	// Change if the classes conflict with other libraries (for example bootstrap)

--- a/src/directives/v-tooltip.js
+++ b/src/directives/v-tooltip.js
@@ -28,7 +28,7 @@ export const defaultOptions = {
   // Default CSS classes applied to the target element of the tooltip
   defaultTargetClass: 'has-tooltip',
   // Is the content HTML by default?
-  defaultHtml: true,
+  defaultHtml: false,
   // Default HTML template of the tooltip element
   // It must include `tooltip-arrow` & `tooltip-inner` CSS classes (can be configured, see below)
   // Change if the classes conflict with other libraries (for example bootstrap)


### PR DESCRIPTION
It is not immediately obvious that v-tooltip accepts HTML by default without reading into the defaults carefully.

It was noted during a pen-test that XSS is possible when user input is displayed in the tooltip.

I believe that the base configuration should be secure as the default and HTML should be enabled where required rather than the other way around. 