### PR TITLE
Fix to 'Top-level declarations' error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import Vue, { VueConstructor, DirectiveOptions, PluginFunction } from 'vue';
 
-const vToolTip: PluginFunction<any>;
+declare const vToolTip: PluginFunction<any>;
 export default vToolTip;
 
 export const VPopover: VueConstructor<Vue>;


### PR DESCRIPTION
Solution to the error:
`3:1 Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.`

Issue: #459 