### PR TITLE
Export added for top level declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import Vue, { VueConstructor, DirectiveOptions, PluginFunction } from 'vue';
 
-const vToolTip: PluginFunction<any>;
+export const vToolTip: PluginFunction<any>;
 export default vToolTip;
 
 export const VPopover: VueConstructor<Vue>;


### PR DESCRIPTION
Tslint says: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

This PR resolve this issue adding export to top level declaration in d.ts file.