### PR TITLE
Describe `false` value on container property

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Or a reactive property:
 - `trigger` - Events triggering the tooltip separated with spaces: `'hover'`, `'click'`, `'focus'` or `'manual'` (`'manual'` can't be combined with any other event).
 - `show` - Boolean to manually open or hide the tooltip.
 - `offset` - Offset of the position (px).
-- `container` - Selector: Container where the tooltip will be appended (e.g. `'body'`).
+- `container` - Selector: Container where the tooltip will be appended (e.g. `'body'`). Set it to `false` to append popover on target parent node.
 - `boundariesElement` - DOM element for the tooltip boundaries.
 - `template` - HTML template of the tooltip.
 - `arrowSelector` - CSS selector to get the arrow element in the tooltip template.


### PR DESCRIPTION
Update README.me to describe the property value. 

According to the current implementation, which is described on #127 and #368 , a `false` value is also allowed on `container` property. It will append the popover on target parent node.