### PR TITLE
Expose isOpen in the popover slot

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -31,7 +31,10 @@
           style="position: relative;"
         >
           <div>
-            <slot name="popover" />
+            <slot
+              name="popover"
+              :is-open="isOpen"
+            />
           </div>
 
           <ResizeObserver v-if="handleResize" @notify="$_handleResize" />


### PR DESCRIPTION
Maybe out of the scope of what this library wants to achieve but I find it useful to be able to grab this via the slot & not have to keep a local copy of the open state 