### PR TITLE
Add guards for `popperInstance`

### DIFF
--- a/src/lib/tooltip.js
+++ b/src/lib/tooltip.js
@@ -240,6 +240,7 @@ export default class Tooltip {
   _setContent (content, options) {
     this.asyncContent = false
     this._applyContent(content, options).then(() => {
+      if (!this.popperInstance) return;
       this.popperInstance.update()
     })
   }
@@ -419,7 +420,9 @@ export default class Tooltip {
     this._tooltipNode.style.display = 'none'
     this._tooltipNode.setAttribute('aria-hidden', 'true')
 
-    this.popperInstance.disableEventListeners()
+    if (this.popperInstance) {
+      this.popperInstance.disableEventListeners()
+    }
 
     clearTimeout(this._disposeTimer)
     const disposeTime = directive.options.disposeTimeout


### PR DESCRIPTION
This change attempts to fix some alerts that have been received where
`popperInstance` is `undefined`, but we try to access methods on it.