### PR TITLE
fix: "this is null" in Popper.js

### DIFF
--- a/packages/v-tooltip/src/components/Popper.js
+++ b/packages/v-tooltip/src/components/Popper.js
@@ -198,7 +198,7 @@ export default () => ({
     popperClass: {
       type: String,
       default () {
-        return getDefaultConfig(this.theme, 'popperClass')
+        return getDefaultConfig(props.theme, 'popperClass')
       },
     },
   },


### PR DESCRIPTION
<img width="684" alt="CleanShot 2022-01-07 at 15 21 52@2x" src="https://user-images.githubusercontent.com/5312996/148557281-c1f7deb6-0696-46c3-8130-4240097e7bba.png">
<img width="412" alt="CleanShot 2022-01-07 at 15 21 59@2x" src="https://user-images.githubusercontent.com/5312996/148557286-7eeeefec-3b27-4e3e-8f83-a60d367c5f6f.png">

