### PR TITLE
Fix iOS touch issue on v-close-popper

### DIFF
--- a/packages/floating-vue/src/directives/v-close-popper.ts
+++ b/packages/floating-vue/src/directives/v-close-popper.ts
@@ -1,9 +1,9 @@
-import { supportsPassive } from '../util/env'
+import { supportsPassive, isIOS } from '../util/env'
 
 function addListeners (el) {
   el.addEventListener('mousedown', addEventProps)
   el.addEventListener('click', addEventProps)
-  el.addEventListener('touchstart', onTouchStart, supportsPassive
+  el.addEventListener('touchstart', onTouchStart, supportsPassive && !isIOS
     ? {
       passive: true,
     }


### PR DESCRIPTION
This PR fixes an issue where the `v-close-popper` directive, when used on a `router-link`, would only close the popper without navigating page on iOS.