### PR TITLE
feat: add Nuxt 4 support

### DIFF
--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "@nuxt/kit": "^3.2.0"
+    "@nuxt/kit": "^3.2.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {


### PR DESCRIPTION
## Summary
- Expand `@nuxt/kit` peer dependency to accept both `^3.2.0` and `^4.0.0`
- Enables installation in Nuxt 4 projects without peer dependency conflicts

## Details
The existing `nuxt.mjs` module implementation is already compatible with Nuxt 4:
- Uses `getContents` pattern (not deprecated EJS templates)
- All `nuxt.options.*` APIs remain valid in Nuxt 4

## Test plan
- [ ] Install in Nuxt 3 project - verify no regression
- [ ] Install in Nuxt 4 project - verify tooltips/dropdowns work
